### PR TITLE
Return an exit code of '1' if paramiko can't be found.

### DIFF
--- a/bin/miq_run_appliance_console.py
+++ b/bin/miq_run_appliance_console.py
@@ -10,7 +10,7 @@ try:
 except:
     print "Please re-run after you have installed 'paramiko'"
     print "Example: easy_install paramiko"
-    sys.exit()
+    sys.exit(1)
 
 DEFAULT_SSH_USER="root"
 


### PR DESCRIPTION
Ran into an issue where paramiko wasn't installed but we weren't reporting an error, made it slow to debug.
